### PR TITLE
Fleshed out implementation of UseGetterOnlyAutoPropertyAnalyzer

### DIFF
--- a/Source/CSharpEssentials.Tests/AnalyzerTestFixture.cs
+++ b/Source/CSharpEssentials.Tests/AnalyzerTestFixture.cs
@@ -18,7 +18,7 @@ namespace CSharpEssentials.Tests
 
             var diagnostics = GetDiagnostics(document);
 
-            Assert.That(diagnostics.All(d => d.Id == diagnosticId), Is.True);
+            Assert.That(diagnostics.Any(d => d.Id == diagnosticId), Is.False);
         }
 
         protected void HasDiagnostic(string markupCode, string diagnosticId)

--- a/Source/CSharpEssentials.Tests/CSharpEssentials.Tests.csproj
+++ b/Source/CSharpEssentials.Tests/CSharpEssentials.Tests.csproj
@@ -69,6 +69,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UseExpressionBodiedMemberAnalyzerTests.cs" />
     <Compile Include="UseExpressionBodiedMemberCodeFixTests.cs" />
+    <Compile Include="UseGetterOnlyAutoPropertyAnalyzerTests.cs" />
+    <Compile Include="UseGetterOnlyAutoPropertyCodeFixTests.cs" />
     <Compile Include="UseNameOfAnalyzerTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
+++ b/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
@@ -26,6 +26,26 @@ class C
         }
 
         [Test]
+        public void AutoPropDeclaredAndUsedInMethodInPartialType()
+        {
+            const string code = @"
+partial class C
+{
+    public int MyProperty { get; private set; }
+}
+
+partial class C
+{
+    public void M()
+    {
+        MyProperty = 0;
+    }
+}";
+
+            NoDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
         public void AutoPropAlreadyReadonly()
         {
             const string code = @"

--- a/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
+++ b/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
@@ -276,5 +276,23 @@ class C
 
             HasDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
         }
+
+        [Test]
+        public void AutoPropUsedInLambdaInConstructorCannotBeReadonly()
+        {
+            const string code = @"
+class C
+{
+    public int P { get; private set; }
+
+    public C()
+    {
+        var f = new Action(() => P = 2);
+    }
+}";
+
+            NoDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
     }
 }

--- a/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
+++ b/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
@@ -1,0 +1,164 @@
+﻿using CSharpEssentials.GetterOnlyAutoProperty;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace CSharpEssentials.Tests
+{
+    [TestFixture]
+    public class UseGetterOnlyAutoPropertyAnalyzerTests : AnalyzerTestFixture
+    {
+        public override DiagnosticAnalyzer CreateAnalyzer() => new UseGetterOnlyAutoPropertyAnalyzer();
+
+        [Test]
+        public void AutoPropDeclaredAndUsedInConstructor()
+        {
+            const string code = @"
+class C
+{
+    public bool MyProperty { get; [|private set;|] }
+    public C(bool f)
+    {
+        MyProperty = f;
+    }
+}";
+
+            HasDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void AutoPropAlreadyReadonly()
+        {
+            const string code = @"
+class C
+{
+    public bool MyProperty { get; }
+    public C(bool f)
+    {
+        MyProperty = f;
+    }
+}";
+            NoDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void NotAnAutoProp()
+        {
+            const string code = @"
+class C
+{
+    public bool MyProperty {
+        get { return false; }
+        private set { ; }
+    }
+
+    public C(bool f)
+    {
+        MyProperty = f;
+    }
+}";
+            NoDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void AutoPropDeclaredAndAssignedInMethod()
+        {
+            const string code = @"
+class C
+{
+    public bool MyProperty { get; private set; }
+    public void Method()
+    {
+        MyProperty = false;
+    }
+}";
+            NoDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void AutoPropDeclaredAndAssignedViaPostIncrement()
+        {
+            const string code = @"
+class C
+{
+    public int MyProperty { get; private set; }
+    public void Method()
+    {
+        MyProperty++;
+    }
+}";
+            NoDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void AutoPropDeclaredAndAssignedViaOrAssignment()
+        {
+            const string code = @"
+class C
+{
+    public int MyProperty { get; private set; }
+    public void Method()
+    {
+        MyProperty |= 0x1;
+    }
+}";
+
+            NoDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void AutoPropDeclaredAndAssignedViaRightShiftAssignment()
+        {
+            const string code = @"
+class C
+{
+    public int MyProperty { get; private set; }
+    public void Method()
+    {
+        MyProperty >>= 1;
+    }
+}";
+
+            NoDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void AutoPropDeclaredAndAssignedComplex()
+        {
+            const string code = @"
+class C
+{
+    public int MyProperty { get; private set; }
+    public float Method()
+    {
+        float y = 0;
+        for (int i = 0; i < 10; i++)
+        {
+            y += (((float)(unchecked((MyProperty) = i))));
+        }
+        return y;
+    }
+}";
+
+            NoDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void AutoPropUsedInNestedConstructor()
+        {
+            const string code = @"
+class C
+{
+    public bool MyProperty { get; private set; }
+    private class Nested
+    {
+        public Nested(C c)
+        {
+            c.MyProperty = false;
+        }
+    }
+}";
+
+            NoDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+    }
+}

--- a/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
+++ b/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
@@ -163,6 +163,24 @@ class C
         }
 
         [Test]
+        public void AutoPropReferencedButNotAssignedInCompoundAssignment()
+        {
+            System.Diagnostics.Debug.Assert(false);
+            const string code = @"
+class C
+{
+    public int MyProperty { get; [|private set;|] }
+    public void Method()
+    {
+        int x = 0;
+        x += MyProperty;
+    }
+}";
+
+            HasDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
         public void AutoPropDeclaredAndAssignedViaRightShiftAssignment()
         {
             const string code = @"

--- a/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
+++ b/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
@@ -165,7 +165,6 @@ class C
         [Test]
         public void AutoPropReferencedButNotAssignedInCompoundAssignment()
         {
-            System.Diagnostics.Debug.Assert(false);
             const string code = @"
 class C
 {

--- a/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
+++ b/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
@@ -26,6 +26,26 @@ class C
         }
 
         [Test]
+        public void AutoPropWrittenInConstructorInPartialClassCanBeReadonly()
+        {
+            const string code = @"
+partial class C
+{
+    public int MyProperty { get; [|private set;|] }
+}
+
+partial class C
+{
+    public C()
+    {
+        MyProperty = 0;
+    }
+}";
+
+            HasDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
         public void AutoPropDeclaredAndUsedInMethodInPartialType()
         {
             const string code = @"
@@ -196,6 +216,48 @@ class C
 }";
 
             NoDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void AutoPropUsedInMultipleConstructorsCanBeReadonly()
+        {
+            const string code = @"
+class C
+{
+    public bool MyProperty { get; [|private set;|] }
+    public C()
+    {
+        MyProperty = false;
+    }
+
+    public (bool b)
+    {
+        MyProperty = b;
+    }
+}";
+
+            HasDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void AutoPropWrittenInConstructorReadInAnotherMethodCanBeReadonly()
+        {
+            const string code = @"
+class C
+{
+    public bool MyProperty { get; [|private set;|] }
+    public C()
+    {
+        MyProperty = false;
+    }
+
+    bool NotProp()
+    {
+        return !MyProperty;
+    }
+}";
+
+            HasDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
         }
     }
 }

--- a/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
+++ b/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyAnalyzerTests.cs
@@ -46,6 +46,23 @@ partial class C
         }
 
         [Test]
+        public void AutoPropInInterfaceUsedExplicitly()
+        {
+            const string code = @"
+interface I
+{
+    int Prop { get; set; }
+}
+
+class C : I
+{
+    int I.Prop { get; set; }
+}";
+
+            NoDiagnostic(code, DiagnosticIds.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
         public void AutoPropAlreadyReadonly()
         {
             const string code = @"

--- a/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyCodeFixTests.cs
+++ b/Source/CSharpEssentials.Tests/UseGetterOnlyAutoPropertyCodeFixTests.cs
@@ -1,0 +1,100 @@
+﻿using CSharpEssentials.GetterOnlyAutoProperty;
+using Microsoft.CodeAnalysis.CodeFixes;
+using NUnit.Framework;
+
+namespace CSharpEssentials.Tests
+{
+    [TestFixture]
+    public class UseGetterOnlyAutoPropertyCodeFixTests : CodeFixTestFixture
+    {
+        public override CodeFixProvider CreateProvider() => new UseGetterOnlyAutoPropertyCodeFix();
+
+        [Test]
+        public void TestSimpleProperty()
+        {
+            const string markupCode = @"
+class C
+{
+    public bool P1 { get; [|private set;|] }
+}";
+
+            const string expected = @"
+class C
+{
+    public bool P1 { get; }
+}";
+
+            TestCodeFix(markupCode, expected, DiagnosticDescriptors.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void TestSetterBeforeGetter()
+        {
+            const string markupCode = @"
+class C
+{
+    public bool P1 { [|private set;|] get; }
+}";
+
+            const string expected = @"
+class C
+{
+    public bool P1 { get; }
+}";
+
+            TestCodeFix(markupCode, expected, DiagnosticDescriptors.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void TestMultilineAutoProp()
+        {
+            const string markupCode = @"
+class C
+{
+    public bool P1
+    {
+        get;
+        [|private set;|]
+    }
+}";
+            // TODO: Note the extra blank line. Should this be eliminated?
+            const string expected = @"
+class C
+{
+    public bool P1
+    {
+        get;
+
+    }
+}";
+
+            TestCodeFix(markupCode, expected, DiagnosticDescriptors.UseGetterOnlyAutoProperty);
+        }
+
+        [Test]
+        public void TestCommentsPreserved()
+        {
+            const string markupCode = @"
+class C
+{
+    public bool P1
+    {
+        get; // Getter comment
+        [|private set;|] // Setter comment
+    }
+}";
+
+            const string expected = @"
+class C
+{
+    public bool P1
+    {
+        get; // Getter comment
+             // Setter comment
+    }
+}";
+
+            TestCodeFix(markupCode, expected, DiagnosticDescriptors.UseGetterOnlyAutoProperty);
+        }
+    }
+}

--- a/Source/CSharpEssentials/GetterOnlyAutoProperty/UseGetterOnlyAutoPropertyAnalyzer.cs
+++ b/Source/CSharpEssentials/GetterOnlyAutoProperty/UseGetterOnlyAutoPropertyAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -6,29 +7,231 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace CSharpEssentials.GetterOnlyAutoProperty
 {
+    /// <summary>
+    /// An analyzer that looks for C# auto properties that could be made readonly.
+    /// Such properties have a private setter that is never invoked outside a constructor.
+    /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    internal class UseGetterOnlyAutoPropertyAnalyzer : DiagnosticAnalyzer
+    internal sealed class UseGetterOnlyAutoPropertyAnalyzer : DiagnosticAnalyzer
     {
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(DiagnosticDescriptors.UseGetterOnlyAutoProperty);
 
-        public override void Initialize(AnalysisContext context)
+        public override void Initialize(AnalysisContext analysisContext)
         {
-            context.RegisterSyntaxNodeAction(AnalzyerAccessorDeclaration, SyntaxKind.SetAccessorDeclaration);
+            analysisContext.RegisterCompilationStartAction(context => { new Tracker(context); });
         }
 
-        private void AnalzyerAccessorDeclaration(SyntaxNodeAnalysisContext context)
+        private class Tracker
         {
-            var accessorDeclaration = (AccessorDeclarationSyntax)context.Node;
+            private readonly HashSet<ISymbol> _declared = new HashSet<ISymbol>();
+            private readonly HashSet<ISymbol> _referenced = new HashSet<ISymbol>();
 
-            if (accessorDeclaration.Body == null &&
-                !accessorDeclaration.SemicolonToken.IsMissing &&
-                accessorDeclaration.Modifiers.Any(SyntaxKind.PrivateKeyword))
+            private static readonly ImmutableArray<SyntaxKind> s_PropertyDeclarationKind = ImmutableArray.Create(SyntaxKind.PropertyDeclaration);
+            private static readonly ImmutableArray<SyntaxKind> s_IdentifierKind = ImmutableArray.Create(SyntaxKind.IdentifierName);
+
+            public Tracker(CompilationStartAnalysisContext context)
             {
-                context.ReportDiagnostic(
-                    Diagnostic.Create(
-                        DiagnosticDescriptors.UseGetterOnlyAutoProperty,
-                        accessorDeclaration.GetLocation()));
+                context.RegisterSyntaxNodeAction(OnPropertyDeclaration, s_PropertyDeclarationKind);
+                context.RegisterSyntaxNodeAction(OnIdentifier, s_IdentifierKind);
+                context.RegisterCompilationEndAction(OnCompilationEnd);
+            }
+
+            /// <summary>
+            /// Look for an auto property declaration with a getter and a private setter.
+            /// </summary>
+            /// <param name="context">The analyzer context.</param>
+            private void OnPropertyDeclaration(SyntaxNodeAnalysisContext context)
+            {
+                var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
+                var accessorList = propertyDeclaration.AccessorList;
+                if (accessorList == null)
+                {
+                    return;
+                }
+
+                // Expect exactly 2 accessors
+                var accessors = accessorList.Accessors;
+                if (accessors.Count != 2)
+                {
+                    return;
+                }
+
+                var firstAccessor = accessors[0];
+                var secondAccessor = accessors[1];
+                if (firstAccessor.Body != null || secondAccessor.Body != null)
+                {
+                    // Not an auto-prop
+                    return;
+                }
+
+                var setter = firstAccessor.IsKind(SyntaxKind.SetAccessorDeclaration) ? firstAccessor :
+                             secondAccessor.IsKind(SyntaxKind.SetAccessorDeclaration) ? secondAccessor : null;
+
+                if (setter == null)
+                {
+                    // Couldn't find a setter
+                    return;
+                }
+
+                if (setter.Modifiers.Any(SyntaxKind.PrivateKeyword))
+                {
+                    // Found a private setter. Add the property (not just the setter) to the list of candidates.
+                    var symbol = context.SemanticModel.GetDeclaredSymbol(propertyDeclaration, context.CancellationToken);
+                    if (symbol != null)
+                    {
+                        _declared.Add(symbol);
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Look for identifiers that are properties. If the identifier is the target
+            /// of an assignment, but does not appear in a constructor, then then add the
+            /// property to the set of 'used' properties.
+            /// </summary>
+            /// <param name="context">The analyzer context for the syntax node.</param>
+            private void OnIdentifier(SyntaxNodeAnalysisContext context)
+            {
+                // Consider: Should this be a block analyzer that looks "down" the tree instead?
+
+                // Is it a property?
+                var property = context.SemanticModel.GetSymbolInfo(context.Node, context.CancellationToken).Symbol;
+                if (property == null || property.Kind != SymbolKind.Property)
+                {
+                    return;
+                }
+
+                // Already seen?
+                if (_referenced.Contains(property))
+                {
+                    return;
+                }
+
+                // Is the property being updated?
+                var node = context.Node;
+                if (!IsUpdatingExpression(ref node))
+                {
+                    return;
+                }
+
+                // Are we in a constructor?
+                if (IsWithinConstructorOf(node.Parent, property.ContainingType, context))
+                {
+                    return;
+                }
+
+                _referenced.Add(property);
+            }
+
+            private static bool IsDescendant(SyntaxNode root, SyntaxNode node)
+            {
+                while (node != null)
+                {
+                    if (node == root)
+                    {
+                        return true;
+                    }
+
+                    node = node.Parent;
+                }
+
+                return false;
+            }
+
+            private static bool IsUpdatingExpression(ref SyntaxNode node)
+            {
+                var identifier = node;
+                for (node = node.Parent; node != null; node = node.Parent)
+                {
+                    switch (node.Kind())
+                    {
+                        // Simple assignment
+                        case SyntaxKind.SimpleAssignmentExpression:
+                            var assignment = (AssignmentExpressionSyntax)node;
+                            return IsDescendant(assignment.Left, identifier);
+
+                        // Implicit assignment
+                        case SyntaxKind.OrAssignmentExpression:
+                        case SyntaxKind.AndAssignmentExpression:
+                        case SyntaxKind.ExclusiveOrAssignmentExpression:
+                        case SyntaxKind.AddAssignmentExpression:
+                        case SyntaxKind.SubtractAssignmentExpression:
+                        case SyntaxKind.MultiplyAssignmentExpression:
+                        case SyntaxKind.DivideAssignmentExpression:
+                        case SyntaxKind.ModuloAssignmentExpression:
+                        case SyntaxKind.LeftShiftAssignmentExpression:
+                        case SyntaxKind.RightShiftAssignmentExpression:
+
+                        // Prefix unary expression
+                        case SyntaxKind.PreIncrementExpression:
+                        case SyntaxKind.PreDecrementExpression:
+
+                        // Postfix unary expression
+                        case SyntaxKind.PostIncrementExpression:
+                        case SyntaxKind.PostDecrementExpression:
+                            return true;
+
+                        // Early loop termination
+                        case SyntaxKind.Block:
+                        case SyntaxKind.ExpressionStatement:
+                            return false;
+                    }
+                }
+
+                return false;
+            }
+
+            private static bool IsWithinConstructorOf(SyntaxNode node, INamedTypeSymbol type, SyntaxNodeAnalysisContext context)
+            {
+                // Are we in a constructor?
+                for (; node != null; node = node.Parent)
+                {
+                    switch (node.Kind())
+                    {
+                        case SyntaxKind.ConstructorDeclaration:
+                            // In a constructor. Is it the constructor for the type that contains the property?
+                            var constructorSymbol = context.SemanticModel.GetDeclaredSymbol(node, context.CancellationToken);
+                            return constructorSymbol != null && (object)constructorSymbol.ContainingType == type;
+
+                        // Early out cases. There are many others, but these are the common ones.
+                        case SyntaxKind.ClassDeclaration:
+                        case SyntaxKind.StructDeclaration:
+                        case SyntaxKind.MethodDeclaration:
+                        case SyntaxKind.PropertyDeclaration:
+                            return false;
+                    }
+                }
+
+                return false;
+            }
+
+            private void OnCompilationEnd(CompilationEndAnalysisContext context)
+            {
+                // Output the the list of remaining candidates
+                _declared.ExceptWith(_referenced);
+                foreach (var symbol in _declared)
+                {
+                    // Report
+                    foreach (var reference in symbol.DeclaringSyntaxReferences)
+                    {
+                        context.CancellationToken.ThrowIfCancellationRequested();
+
+                        // The span should be on the setter, but the symbol is for the whole property declaration.
+                        var declarationNode = reference.GetSyntax(context.CancellationToken) as PropertyDeclarationSyntax;
+                        foreach (var accessor in declarationNode.AccessorList.Accessors)
+                        {
+                            if (accessor.IsKind(SyntaxKind.SetAccessorDeclaration))
+                            {
+                                context.ReportDiagnostic(
+                                    Diagnostic.Create(
+                                        DiagnosticDescriptors.UseGetterOnlyAutoProperty,
+                                        accessor.GetLocation()));
+                                break;
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/Source/CSharpEssentials/GetterOnlyAutoProperty/UseGetterOnlyAutoPropertyAnalyzer.cs
+++ b/Source/CSharpEssentials/GetterOnlyAutoProperty/UseGetterOnlyAutoPropertyAnalyzer.cs
@@ -90,7 +90,7 @@ namespace CSharpEssentials.GetterOnlyAutoProperty
             foreach (var property in allProperties)
             {
                 var propertySymbol = (IPropertySymbol)property;
-                if (!propertySymbol.IsReadOnly)
+                if (!propertySymbol.IsReadOnly && propertySymbol.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
                 {
                     var setMethod = propertySymbol.SetMethod;
                     if (setMethod != null && setMethod.DeclaredAccessibility == Accessibility.Private)

--- a/Source/CSharpEssentials/GetterOnlyAutoProperty/UseGetterOnlyAutoPropertyAnalyzer.cs
+++ b/Source/CSharpEssentials/GetterOnlyAutoProperty/UseGetterOnlyAutoPropertyAnalyzer.cs
@@ -96,11 +96,15 @@ namespace CSharpEssentials.GetterOnlyAutoProperty
                     if (setMethod != null && setMethod.DeclaredAccessibility == Accessibility.Private)
                     {
                         // Find the syntax for the setter.
-                        var declaration = setMethod.DeclaringSyntaxReferences.FirstOrDefault().GetSyntax(cancellationToken) as AccessorDeclarationSyntax;
-                        if (declaration != null && declaration.Body == null)
+                        var reference = setMethod.DeclaringSyntaxReferences.FirstOrDefault();
+                        if (reference != null)
                         {
-                            // An empty body indicates it's an auto-prop
-                            (candidates ?? (candidates = new HashSet<ISymbol>())).Add(propertySymbol);
+                            var declaration = reference.GetSyntax(cancellationToken) as AccessorDeclarationSyntax;
+                            if (declaration != null && declaration.Body == null)
+                            {
+                                // An empty body indicates it's an auto-prop
+                                (candidates ?? (candidates = new HashSet<ISymbol>())).Add(propertySymbol);
+                            }
                         }
                     }
                 }
@@ -131,12 +135,8 @@ namespace CSharpEssentials.GetterOnlyAutoProperty
             {
                 switch (node.Kind())
                 {
-                    // Simple assignment
+                    // Simple or compound assignment
                     case SyntaxKind.SimpleAssignmentExpression:
-                        var assignment = (AssignmentExpressionSyntax)node;
-                        return IsDescendant(assignment.Left, identifier);
-
-                    // Implicit assignment
                     case SyntaxKind.OrAssignmentExpression:
                     case SyntaxKind.AndAssignmentExpression:
                     case SyntaxKind.ExclusiveOrAssignmentExpression:
@@ -147,6 +147,8 @@ namespace CSharpEssentials.GetterOnlyAutoProperty
                     case SyntaxKind.ModuloAssignmentExpression:
                     case SyntaxKind.LeftShiftAssignmentExpression:
                     case SyntaxKind.RightShiftAssignmentExpression:
+                        var assignment = (AssignmentExpressionSyntax)node;
+                        return IsDescendant(assignment.Left, identifier);
 
                     // Prefix unary expression
                     case SyntaxKind.PreIncrementExpression:

--- a/Source/CSharpEssentials/GetterOnlyAutoProperty/UseGetterOnlyAutoPropertyAnalyzer.cs
+++ b/Source/CSharpEssentials/GetterOnlyAutoProperty/UseGetterOnlyAutoPropertyAnalyzer.cs
@@ -173,6 +173,12 @@ namespace CSharpEssentials.GetterOnlyAutoProperty
                         var constructorSymbol = semanticModel.GetDeclaredSymbol(node, cancellationToken);
                         return constructorSymbol != null && (object)constructorSymbol.ContainingType == type;
 
+                    // If it's in a lambda expression, even if in a constructor, then it counts as a
+                    // non-constructor case.
+                    case SyntaxKind.SimpleLambdaExpression:
+                    case SyntaxKind.ParenthesizedLambdaExpression:
+                        return false;
+
                     // Early out cases. There are many others, but these are the common ones.
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.StructDeclaration:

--- a/Source/CSharpEssentials/GetterOnlyAutoProperty/UseGetterOnlyAutoPropertyAnalyzer.cs
+++ b/Source/CSharpEssentials/GetterOnlyAutoProperty/UseGetterOnlyAutoPropertyAnalyzer.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using System.Threading;
 
 namespace CSharpEssentials.GetterOnlyAutoProperty
 {
@@ -19,220 +21,194 @@ namespace CSharpEssentials.GetterOnlyAutoProperty
 
         public override void Initialize(AnalysisContext analysisContext)
         {
-            analysisContext.RegisterCompilationStartAction(context => { new Tracker(context); });
+            analysisContext.RegisterSymbolAction(OnType, SymbolKind.NamedType);
         }
 
-        private class Tracker
+        private static void OnType(SymbolAnalysisContext context)
         {
-            private readonly HashSet<ISymbol> _declared = new HashSet<ISymbol>();
-            private readonly HashSet<ISymbol> _referenced = new HashSet<ISymbol>();
-
-            private static readonly ImmutableArray<SyntaxKind> s_PropertyDeclarationKind = ImmutableArray.Create(SyntaxKind.PropertyDeclaration);
-            private static readonly ImmutableArray<SyntaxKind> s_IdentifierKind = ImmutableArray.Create(SyntaxKind.IdentifierName);
-
-            public Tracker(CompilationStartAnalysisContext context)
+            var type = (INamedTypeSymbol)context.Symbol;
+            var candidates = GetAutoPropsWithPrivateSetters(type, context.CancellationToken);
+            if (candidates == null || candidates.Count == 0)
             {
-                context.RegisterSyntaxNodeAction(OnPropertyDeclaration, s_PropertyDeclarationKind);
-                context.RegisterSyntaxNodeAction(OnIdentifier, s_IdentifierKind);
-                context.RegisterCompilationEndAction(OnCompilationEnd);
+                return;
             }
 
-            /// <summary>
-            /// Look for an auto property declaration with a getter and a private setter.
-            /// </summary>
-            /// <param name="context">The analyzer context.</param>
-            private void OnPropertyDeclaration(SyntaxNodeAnalysisContext context)
+            // Staying within this type, look for assignments to candidate properties.
+            // This outer loop is for partial types.
+            foreach (var reference in type.DeclaringSyntaxReferences)
             {
-                var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
-                var accessorList = propertyDeclaration.AccessorList;
-                if (accessorList == null)
-                {
-                    return;
-                }
+                SemanticModel model = null;
 
-                // Expect exactly 2 accessors
-                var accessors = accessorList.Accessors;
-                if (accessors.Count != 2)
+                // Walk the tree looking for identifiers
+                foreach (var node in reference.GetSyntax(context.CancellationToken).DescendantNodes())
                 {
-                    return;
-                }
-
-                var firstAccessor = accessors[0];
-                var secondAccessor = accessors[1];
-                if (firstAccessor.Body != null || secondAccessor.Body != null)
-                {
-                    // Not an auto-prop
-                    return;
-                }
-
-                var setter = firstAccessor.IsKind(SyntaxKind.SetAccessorDeclaration) ? firstAccessor :
-                             secondAccessor.IsKind(SyntaxKind.SetAccessorDeclaration) ? secondAccessor : null;
-
-                if (setter == null)
-                {
-                    // Couldn't find a setter
-                    return;
-                }
-
-                if (setter.Modifiers.Any(SyntaxKind.PrivateKeyword))
-                {
-                    // Found a private setter. Add the property (not just the setter) to the list of candidates.
-                    var symbol = context.SemanticModel.GetDeclaredSymbol(propertyDeclaration, context.CancellationToken);
-                    if (symbol != null)
+                    if (node.IsKind(SyntaxKind.IdentifierName))
                     {
-                        _declared.Add(symbol);
-                    }
-                }
-            }
-
-            /// <summary>
-            /// Look for identifiers that are properties. If the identifier is the target
-            /// of an assignment, but does not appear in a constructor, then then add the
-            /// property to the set of 'used' properties.
-            /// </summary>
-            /// <param name="context">The analyzer context for the syntax node.</param>
-            private void OnIdentifier(SyntaxNodeAnalysisContext context)
-            {
-                // Consider: Should this be a block analyzer that looks "down" the tree instead?
-
-                // Is it a property?
-                var property = context.SemanticModel.GetSymbolInfo(context.Node, context.CancellationToken).Symbol;
-                if (property == null || property.Kind != SymbolKind.Property)
-                {
-                    return;
-                }
-
-                // Already seen?
-                if (_referenced.Contains(property))
-                {
-                    return;
-                }
-
-                // Is the property being updated?
-                var node = context.Node;
-                if (!IsUpdatingExpression(ref node))
-                {
-                    return;
-                }
-
-                // Are we in a constructor?
-                if (IsWithinConstructorOf(node.Parent, property.ContainingType, context))
-                {
-                    return;
-                }
-
-                _referenced.Add(property);
-            }
-
-            private static bool IsDescendant(SyntaxNode root, SyntaxNode node)
-            {
-                while (node != null)
-                {
-                    if (node == root)
-                    {
-                        return true;
-                    }
-
-                    node = node.Parent;
-                }
-
-                return false;
-            }
-
-            private static bool IsUpdatingExpression(ref SyntaxNode node)
-            {
-                var identifier = node;
-                for (node = node.Parent; node != null; node = node.Parent)
-                {
-                    switch (node.Kind())
-                    {
-                        // Simple assignment
-                        case SyntaxKind.SimpleAssignmentExpression:
-                            var assignment = (AssignmentExpressionSyntax)node;
-                            return IsDescendant(assignment.Left, identifier);
-
-                        // Implicit assignment
-                        case SyntaxKind.OrAssignmentExpression:
-                        case SyntaxKind.AndAssignmentExpression:
-                        case SyntaxKind.ExclusiveOrAssignmentExpression:
-                        case SyntaxKind.AddAssignmentExpression:
-                        case SyntaxKind.SubtractAssignmentExpression:
-                        case SyntaxKind.MultiplyAssignmentExpression:
-                        case SyntaxKind.DivideAssignmentExpression:
-                        case SyntaxKind.ModuloAssignmentExpression:
-                        case SyntaxKind.LeftShiftAssignmentExpression:
-                        case SyntaxKind.RightShiftAssignmentExpression:
-
-                        // Prefix unary expression
-                        case SyntaxKind.PreIncrementExpression:
-                        case SyntaxKind.PreDecrementExpression:
-
-                        // Postfix unary expression
-                        case SyntaxKind.PostIncrementExpression:
-                        case SyntaxKind.PostDecrementExpression:
-                            return true;
-
-                        // Early loop termination
-                        case SyntaxKind.Block:
-                        case SyntaxKind.ExpressionStatement:
-                            return false;
-                    }
-                }
-
-                return false;
-            }
-
-            private static bool IsWithinConstructorOf(SyntaxNode node, INamedTypeSymbol type, SyntaxNodeAnalysisContext context)
-            {
-                // Are we in a constructor?
-                for (; node != null; node = node.Parent)
-                {
-                    switch (node.Kind())
-                    {
-                        case SyntaxKind.ConstructorDeclaration:
-                            // In a constructor. Is it the constructor for the type that contains the property?
-                            var constructorSymbol = context.SemanticModel.GetDeclaredSymbol(node, context.CancellationToken);
-                            return constructorSymbol != null && (object)constructorSymbol.ContainingType == type;
-
-                        // Early out cases. There are many others, but these are the common ones.
-                        case SyntaxKind.ClassDeclaration:
-                        case SyntaxKind.StructDeclaration:
-                        case SyntaxKind.MethodDeclaration:
-                        case SyntaxKind.PropertyDeclaration:
-                            return false;
-                    }
-                }
-
-                return false;
-            }
-
-            private void OnCompilationEnd(CompilationEndAnalysisContext context)
-            {
-                // Output the the list of remaining candidates
-                _declared.ExceptWith(_referenced);
-                foreach (var symbol in _declared)
-                {
-                    // Report
-                    foreach (var reference in symbol.DeclaringSyntaxReferences)
-                    {
-                        context.CancellationToken.ThrowIfCancellationRequested();
-
-                        // The span should be on the setter, but the symbol is for the whole property declaration.
-                        var declarationNode = reference.GetSyntax(context.CancellationToken) as PropertyDeclarationSyntax;
-                        foreach (var accessor in declarationNode.AccessorList.Accessors)
+                        if (model == null)
                         {
-                            if (accessor.IsKind(SyntaxKind.SetAccessorDeclaration))
+                            model = context.Compilation.GetSemanticModel(reference.SyntaxTree);
+                        }
+
+                        var property = model.GetSymbolInfo(node, context.CancellationToken).Symbol;
+                        if (property?.Kind == SymbolKind.Property &&
+                            candidates.Contains(property) &&
+                            IsIdentifierWithinAnAssignmentButNotInAConstructor(node, type, model, context.CancellationToken))
+                        {
+                            if (candidates.Remove(property) && candidates.Count == 0)
                             {
-                                context.ReportDiagnostic(
-                                    Diagnostic.Create(
-                                        DiagnosticDescriptors.UseGetterOnlyAutoProperty,
-                                        accessor.GetLocation()));
                                 break;
                             }
                         }
                     }
                 }
             }
+
+            // Anything left in the candidates set should be reported.
+            foreach (var candidate in candidates)
+            {
+                context.ReportDiagnostic(CreateDiagnostic(candidate, context.CancellationToken));
+            }
+        }
+
+        private static bool IsIdentifierWithinAnAssignmentButNotInAConstructor(SyntaxNode identifier, INamedTypeSymbol containingType, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            // Is the property being updated but not within the constructor?
+            var node = identifier;
+            if (!IsUpdatingExpression(ref node))
+            {
+                return false;
+            }
+
+            return !IsWithinConstructorOf(node.Parent, containingType, semanticModel, cancellationToken);
+        }
+
+        private static HashSet<ISymbol> GetAutoPropsWithPrivateSetters(INamedTypeSymbol type, CancellationToken cancellationToken)
+        {
+            HashSet<ISymbol> candidates = null;
+
+            var allProperties = type.GetMembers().Where(s => s.Kind == SymbolKind.Property);
+            foreach (var property in allProperties)
+            {
+                var propertySymbol = (IPropertySymbol)property;
+                if (!propertySymbol.IsReadOnly)
+                {
+                    var setMethod = propertySymbol.SetMethod;
+                    if (setMethod != null && setMethod.DeclaredAccessibility == Accessibility.Private)
+                    {
+                        // Find the syntax for the setter.
+                        var declaration = setMethod.DeclaringSyntaxReferences.FirstOrDefault().GetSyntax(cancellationToken) as AccessorDeclarationSyntax;
+                        if (declaration != null && declaration.Body == null)
+                        {
+                            // An empty body indicates it's an auto-prop
+                            (candidates ?? (candidates = new HashSet<ISymbol>())).Add(propertySymbol);
+                        }
+                    }
+                }
+            }
+
+            return candidates;
+        }
+
+        private static bool IsDescendant(SyntaxNode root, SyntaxNode node)
+        {
+            while (node != null)
+            {
+                if (node == root)
+                {
+                    return true;
+                }
+
+                node = node.Parent;
+            }
+
+            return false;
+        }
+
+        private static bool IsUpdatingExpression(ref SyntaxNode node)
+        {
+            var identifier = node;
+            for (node = node.Parent; node != null; node = node.Parent)
+            {
+                switch (node.Kind())
+                {
+                    // Simple assignment
+                    case SyntaxKind.SimpleAssignmentExpression:
+                        var assignment = (AssignmentExpressionSyntax)node;
+                        return IsDescendant(assignment.Left, identifier);
+
+                    // Implicit assignment
+                    case SyntaxKind.OrAssignmentExpression:
+                    case SyntaxKind.AndAssignmentExpression:
+                    case SyntaxKind.ExclusiveOrAssignmentExpression:
+                    case SyntaxKind.AddAssignmentExpression:
+                    case SyntaxKind.SubtractAssignmentExpression:
+                    case SyntaxKind.MultiplyAssignmentExpression:
+                    case SyntaxKind.DivideAssignmentExpression:
+                    case SyntaxKind.ModuloAssignmentExpression:
+                    case SyntaxKind.LeftShiftAssignmentExpression:
+                    case SyntaxKind.RightShiftAssignmentExpression:
+
+                    // Prefix unary expression
+                    case SyntaxKind.PreIncrementExpression:
+                    case SyntaxKind.PreDecrementExpression:
+
+                    // Postfix unary expression
+                    case SyntaxKind.PostIncrementExpression:
+                    case SyntaxKind.PostDecrementExpression:
+                        return true;
+
+                    // Early loop termination
+                    case SyntaxKind.Block:
+                    case SyntaxKind.ExpressionStatement:
+                        return false;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsWithinConstructorOf(SyntaxNode node, INamedTypeSymbol type, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            // Are we in a constructor?
+            for (; node != null; node = node.Parent)
+            {
+                switch (node.Kind())
+                {
+                    case SyntaxKind.ConstructorDeclaration:
+                        // In a constructor. Is it the constructor for the type that contains the property?
+                        var constructorSymbol = semanticModel.GetDeclaredSymbol(node, cancellationToken);
+                        return constructorSymbol != null && (object)constructorSymbol.ContainingType == type;
+
+                    // Early out cases. There are many others, but these are the common ones.
+                    case SyntaxKind.ClassDeclaration:
+                    case SyntaxKind.StructDeclaration:
+                    case SyntaxKind.MethodDeclaration:
+                    case SyntaxKind.PropertyDeclaration:
+                        return false;
+                }
+            }
+
+            return false;
+        }
+
+        private static Diagnostic CreateDiagnostic(ISymbol symbol, CancellationToken cancellationToken)
+        {
+            foreach (var reference in symbol.DeclaringSyntaxReferences)
+            {
+                // The span should be on the setter, but the symbol is for the whole property declaration.
+                var declarationNode = reference.GetSyntax(cancellationToken) as PropertyDeclarationSyntax;
+                foreach (var accessor in declarationNode.AccessorList.Accessors)
+                {
+                    if (accessor.IsKind(SyntaxKind.SetAccessorDeclaration))
+                    {
+                        return Diagnostic.Create(
+                                DiagnosticDescriptors.UseGetterOnlyAutoProperty,
+                                accessor.GetLocation());
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Checks if the property is assigned anywhere outside a constructor of its containing type. If so, the setter can't be removed.

Added unit tests.