### PR TITLE
Add "Expand expression-bodied member" member refactoring

### DIFF
--- a/Source/CSharpEssentials.Tests/CSharpEssentials.Tests.csproj
+++ b/Source/CSharpEssentials.Tests/CSharpEssentials.Tests.csproj
@@ -57,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConvertToInterpolatedString\ConvertToInterpolatedStringRefactoringTests.cs" />
+    <Compile Include="ExpandExpressionBodiedMember\ExpandExpressionBodiedMemberRefactoringTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UseExpressionBodiedMember\UseExpressionBodiedMemberAnalyzerTests.cs" />
     <Compile Include="UseExpressionBodiedMember\UseExpressionBodiedMemberCodeFixTests.cs" />

--- a/Source/CSharpEssentials.Tests/ExpandExpressionBodiedMember/ExpandExpressionBodiedMemberRefactoringTests.cs
+++ b/Source/CSharpEssentials.Tests/ExpandExpressionBodiedMember/ExpandExpressionBodiedMemberRefactoringTests.cs
@@ -1,0 +1,187 @@
+﻿using CSharpEssentials.ExpandExpressionBodiedMember;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using NUnit.Framework;
+using RoslynNUnitLight;
+
+namespace CSharpEssentials.Tests.ExpandExpressionBodiedMember
+{
+    public class ExpandExpressionBodiedMemberRefactoringTests : CodeRefactoringTestFixture
+    {
+        protected override string LanguageName => LanguageNames.CSharp;
+        protected override CodeRefactoringProvider CreateProvider() => new ExpandExpressionBodiedMemberRefactoring();
+
+        [Test]
+        public void TestSimpleProperty()
+        {
+            const string markupCode = @"
+class C
+{
+    [|int P => 42;|]
+}
+";
+
+            const string expected = @"
+class C
+{
+    int P
+    {
+        get
+        {
+            return 42;
+        }
+    }
+}
+";
+
+            TestCodeRefactoring(markupCode, expected);
+        }
+
+        [Test]
+        public void TestPropertyBeforeAnotherProperty()
+        {
+            const string markupCode = @"
+class C
+{
+    [|int P1 => 42;|]
+    int P2 { get { return 42; } }
+}
+";
+
+            const string expected = @"
+class C
+{
+    int P1
+    {
+        get
+        {
+            return 42;
+        }
+    }
+
+    int P2 { get { return 42; } }
+}
+";
+
+            TestCodeRefactoring(markupCode, expected);
+        }
+
+        [Test]
+        public void TestSimpleIndexer()
+        {
+            const string markupCode = @"
+class C
+{
+    [|int this[int index] => 42;|]
+}
+";
+
+            const string expected = @"
+class C
+{
+    int this[int index]
+    {
+        get
+        {
+            return 42;
+        }
+    }
+}
+";
+
+            TestCodeRefactoring(markupCode, expected);
+        }
+
+        [Test]
+        public void TestSimpleMethod()
+        {
+            const string markupCode = @"
+class C
+{
+    [|int M() => 42;|]
+}
+";
+
+            const string expected = @"
+class C
+{
+    int M()
+    {
+        return 42;
+    }
+}
+";
+
+            TestCodeRefactoring(markupCode, expected);
+        }
+
+        [Test]
+        public void TestSimpleOperator()
+        {
+            const string markupCode = @"
+class C
+{
+    [|int operator +(C c1, C c2) => 42;|]
+}
+";
+
+            const string expected = @"
+class C
+{
+    int operator +(C c1, C c2)
+    {
+        return 42;
+    }
+}
+";
+
+            TestCodeRefactoring(markupCode, expected);
+        }
+
+        [Test]
+        public void TestSimpleConversionOperator()
+        {
+            const string markupCode = @"
+class C
+{
+    [|public static implicit operator int (C c) => 42;|]
+}
+";
+
+            const string expected = @"
+class C
+{
+    public static implicit operator int (C c)
+    {
+        return 42;
+    }
+}
+";
+
+            TestCodeRefactoring(markupCode, expected);
+        }
+
+        [Test]
+        public void TestMethodWithComment()
+        {
+            const string markupCode = @"
+class C
+{
+    [|int M() => 42;|] // comment
+}
+";
+
+            const string expected = @"
+class C
+{
+    int M()
+    {
+        return 42; // comment
+    }
+}
+";
+
+            TestCodeRefactoring(markupCode, expected);
+        }
+    }
+}

--- a/Source/CSharpEssentials.Tests/UseExpressionBodiedMember/UseExpressionBodiedMemberCodeFixTests.cs
+++ b/Source/CSharpEssentials.Tests/UseExpressionBodiedMember/UseExpressionBodiedMemberCodeFixTests.cs
@@ -98,6 +98,52 @@ class C
         }
 
         [Test]
+        public void TestSimpleOperator()
+        {
+            const string markupCode = @"
+class C
+{
+    [|int operator +(C c1, C c2)
+    {
+        return 42;
+    }|]
+}
+";
+
+            const string expected = @"
+class C
+{
+    int operator +(C c1, C c2) => 42;
+}
+";
+
+            TestCodeFix(markupCode, expected, DiagnosticDescriptors.UseExpressionBodiedMember);
+        }
+
+        [Test]
+        public void TestSimpleConversionOperator()
+        {
+            const string markupCode = @"
+class C
+{
+    [|public static implicit operator int (C c)
+    {
+        return 42;
+    }|]
+}
+";
+
+            const string expected = @"
+class C
+{
+    public static implicit operator int (C c) => 42;
+}
+";
+
+            TestCodeFix(markupCode, expected, DiagnosticDescriptors.UseExpressionBodiedMember);
+        }
+
+        [Test]
         public void TestMethodWithComment()
         {
             const string markupCode = @"

--- a/Source/CSharpEssentials/CSharpEssentials.csproj
+++ b/Source/CSharpEssentials/CSharpEssentials.csproj
@@ -14,6 +14,7 @@
     <Compile Include="DiagnosticCategories.cs" />
     <Compile Include="DiagnosticDescriptors.cs" />
     <Compile Include="DiagnosticIds.cs" />
+    <Compile Include="ExpandExpressionBodiedMember\ExpandExpressionBodiedMemberRefactoring.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="GetterOnlyAutoProperty\UseGetterOnlyAutoPropertyAnalyzer.cs" />
     <Compile Include="GetterOnlyAutoProperty\UseGetterOnlyAutoPropertyCodeFix.cs" />
@@ -67,6 +68,7 @@
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/CSharpEssentials/ConvertToInterpolatedString/ConvertToInterpolatedStringRefactoring.cs
+++ b/Source/CSharpEssentials/ConvertToInterpolatedString/ConvertToInterpolatedStringRefactoring.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;

--- a/Source/CSharpEssentials/ExpandExpressionBodiedMember/ExpandExpressionBodiedMemberRefactoring.cs
+++ b/Source/CSharpEssentials/ExpandExpressionBodiedMember/ExpandExpressionBodiedMemberRefactoring.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace CSharpEssentials.ExpandExpressionBodiedMember
+{
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp)]
+    public class ExpandExpressionBodiedMemberRefactoring : CodeRefactoringProvider
+    {
+        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
+
+            var declaration = root.FindNode(context.Span).FirstAncestorOrSelf<MemberDeclarationSyntax>();
+
+            switch (declaration?.Kind())
+            {
+                case SyntaxKind.MethodDeclaration:
+                    var methodDeclaration = (MethodDeclarationSyntax)declaration;
+                    if (methodDeclaration.ExpressionBody != null)
+                    {
+                        context.RegisterRefactoring(
+                            CodeAction.Create(
+                                "Expand expression-bodied member",
+                                c => HandleMethodDeclaration(methodDeclaration, context.Document, c)));
+                    }
+
+                    break;
+
+                case SyntaxKind.OperatorDeclaration:
+                    var operatorDeclaration = (OperatorDeclarationSyntax)declaration;
+                    if (operatorDeclaration.ExpressionBody != null)
+                    {
+                        context.RegisterRefactoring(
+                            CodeAction.Create(
+                                "Expand expression-bodied member",
+                                c => HandleOperatorDeclaration(operatorDeclaration, context.Document, c)));
+                    }
+
+                    break;
+
+                case SyntaxKind.ConversionOperatorDeclaration:
+                    var conversionOperatorDeclaration = (ConversionOperatorDeclarationSyntax)declaration;
+                    if (conversionOperatorDeclaration.ExpressionBody != null)
+                    {
+                        context.RegisterRefactoring(
+                            CodeAction.Create(
+                                "Expand expression-bodied member",
+                                c => HandleConversionOperatorDeclaration(conversionOperatorDeclaration, context.Document, c)));
+                    }
+
+                    break;
+
+                case SyntaxKind.PropertyDeclaration:
+                    var propertyDeclaration = (PropertyDeclarationSyntax)declaration;
+                    if (propertyDeclaration.ExpressionBody != null)
+                    {
+                        context.RegisterRefactoring(
+                            CodeAction.Create(
+                                "Expand expression-bodied member",
+                                c => HandlePropertyDeclaration(propertyDeclaration, context.Document, c)));
+                    }
+
+                    break;
+
+                case SyntaxKind.IndexerDeclaration:
+                    var indexerDeclaration = (IndexerDeclarationSyntax)declaration;
+                    if (indexerDeclaration.ExpressionBody != null)
+                    {
+                        context.RegisterRefactoring(
+                            CodeAction.Create(
+                                "Expand expression-bodied member",
+                                c => HandleIndexerDeclaration(indexerDeclaration, context.Document, c)));
+                    }
+
+                    break;
+            }
+        }
+
+        private async Task<Document> HandleMethodDeclaration(MethodDeclarationSyntax declaration, Document document, CancellationToken cancellationToken)
+        {
+            var returnStatement = SyntaxFactory.ReturnStatement(
+                returnKeyword: SyntaxFactory.Token(SyntaxKind.ReturnKeyword),
+                expression: declaration.ExpressionBody.Expression,
+                semicolonToken: declaration.SemicolonToken);
+
+            var newDeclaration = declaration
+                .WithBody(SyntaxFactory.Block(returnStatement))
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default(SyntaxToken))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            var oldRoot = await document.GetSyntaxRootAsync(cancellationToken);
+            var newRoot = oldRoot.ReplaceNode(declaration, newDeclaration);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private async Task<Document> HandleOperatorDeclaration(OperatorDeclarationSyntax declaration, Document document, CancellationToken cancellationToken)
+        {
+            var returnStatement = SyntaxFactory.ReturnStatement(
+                returnKeyword: SyntaxFactory.Token(SyntaxKind.ReturnKeyword),
+                expression: declaration.ExpressionBody.Expression,
+                semicolonToken: declaration.SemicolonToken);
+
+            var newDeclaration = declaration
+                .WithBody(SyntaxFactory.Block(returnStatement))
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default(SyntaxToken))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            var oldRoot = await document.GetSyntaxRootAsync(cancellationToken);
+            var newRoot = oldRoot.ReplaceNode(declaration, newDeclaration);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private async Task<Document> HandleConversionOperatorDeclaration(ConversionOperatorDeclarationSyntax declaration, Document document, CancellationToken cancellationToken)
+        {
+            var returnStatement = SyntaxFactory.ReturnStatement(
+                returnKeyword: SyntaxFactory.Token(SyntaxKind.ReturnKeyword),
+                expression: declaration.ExpressionBody.Expression,
+                semicolonToken: declaration.SemicolonToken);
+
+            var newDeclaration = declaration
+                .WithBody(SyntaxFactory.Block(returnStatement))
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default(SyntaxToken))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            var oldRoot = await document.GetSyntaxRootAsync(cancellationToken);
+            var newRoot = oldRoot.ReplaceNode(declaration, newDeclaration);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private async Task<Document> HandlePropertyDeclaration(PropertyDeclarationSyntax declaration, Document document, CancellationToken cancellationToken)
+        {
+            var returnStatement = SyntaxFactory.ReturnStatement(
+                returnKeyword: SyntaxFactory.Token(SyntaxKind.ReturnKeyword),
+                expression: declaration.ExpressionBody.Expression,
+                semicolonToken: declaration.SemicolonToken);
+
+            var accessorDeclaration = SyntaxFactory.AccessorDeclaration(
+                kind: SyntaxKind.GetAccessorDeclaration,
+                body: SyntaxFactory.Block(returnStatement));
+
+            var newDeclaration = declaration
+                .WithAccessorList(
+                    SyntaxFactory.AccessorList(
+                        SyntaxFactory.SingletonList(accessorDeclaration)))
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default(SyntaxToken))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            var oldRoot = await document.GetSyntaxRootAsync(cancellationToken);
+            var newRoot = oldRoot.ReplaceNode(declaration, newDeclaration);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private async Task<Document> HandleIndexerDeclaration(IndexerDeclarationSyntax declaration, Document document, CancellationToken cancellationToken)
+        {
+            var returnStatement = SyntaxFactory.ReturnStatement(
+                returnKeyword: SyntaxFactory.Token(SyntaxKind.ReturnKeyword),
+                expression: declaration.ExpressionBody.Expression,
+                semicolonToken: declaration.SemicolonToken);
+
+            var accessorDeclaration = SyntaxFactory.AccessorDeclaration(
+                kind: SyntaxKind.GetAccessorDeclaration,
+                body: SyntaxFactory.Block(returnStatement));
+
+            var newDeclaration = declaration
+                .WithAccessorList(
+                    SyntaxFactory.AccessorList(
+                        SyntaxFactory.SingletonList(accessorDeclaration)))
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default(SyntaxToken))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            var oldRoot = await document.GetSyntaxRootAsync(cancellationToken);
+            var newRoot = oldRoot.ReplaceNode(declaration, newDeclaration);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+    }
+}

--- a/Source/CSharpEssentials/UseExpressionBodiedMember/UseExpressionBodiedMemberCodeFix.cs
+++ b/Source/CSharpEssentials/UseExpressionBodiedMember/UseExpressionBodiedMemberCodeFix.cs
@@ -11,161 +11,161 @@ using Microsoft.CodeAnalysis.Formatting;
 
 namespace CSharpEssentials.UseExpressionBodiedMember
 {
-	[ExportCodeFixProvider(LanguageNames.CSharp, Name = "Use Expression-bodied Member")]
-	internal class UseExpressionBodiedMemberCodeFix : CodeFixProvider
-	{
-		public override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
-			var declaration = root.FindNode(context.Span)?.FirstAncestorOrSelf<MemberDeclarationSyntax>();
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = "Use Expression-bodied Member")]
+    internal class UseExpressionBodiedMemberCodeFix : CodeFixProvider
+    {
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
+            var declaration = root.FindNode(context.Span)?.FirstAncestorOrSelf<MemberDeclarationSyntax>();
 
-			switch (declaration?.Kind())
-			{
-				case SyntaxKind.MethodDeclaration:
-					context.RegisterCodeFix(
-						CodeAction.Create("Use expression-bodied member", c => ReplaceWithExpressionBodiedMember(context.Document, (MethodDeclarationSyntax)declaration, c)),
-						context.Diagnostics);
-					break;
+            switch (declaration?.Kind())
+            {
+                case SyntaxKind.MethodDeclaration:
+                    context.RegisterCodeFix(
+                        CodeAction.Create("Use expression-bodied member", c => ReplaceWithExpressionBodiedMember(context.Document, (MethodDeclarationSyntax)declaration, c)),
+                        context.Diagnostics);
+                    break;
 
-				case SyntaxKind.OperatorDeclaration:
-					context.RegisterCodeFix(
-						CodeAction.Create("Use expression-bodied member", c => ReplaceWithExpressionBodiedMember(context.Document, (OperatorDeclarationSyntax)declaration, c)),
-						context.Diagnostics);
-					break;
+                case SyntaxKind.OperatorDeclaration:
+                    context.RegisterCodeFix(
+                        CodeAction.Create("Use expression-bodied member", c => ReplaceWithExpressionBodiedMember(context.Document, (OperatorDeclarationSyntax)declaration, c)),
+                        context.Diagnostics);
+                    break;
 
-				case SyntaxKind.ConversionOperatorDeclaration:
-					context.RegisterCodeFix(
-						CodeAction.Create("Use expression-bodied member", c => ReplaceWithExpressionBodiedMember(context.Document, (ConversionOperatorDeclarationSyntax)declaration, c)),
-						context.Diagnostics);
-					break;
+                case SyntaxKind.ConversionOperatorDeclaration:
+                    context.RegisterCodeFix(
+                        CodeAction.Create("Use expression-bodied member", c => ReplaceWithExpressionBodiedMember(context.Document, (ConversionOperatorDeclarationSyntax)declaration, c)),
+                        context.Diagnostics);
+                    break;
 
-				case SyntaxKind.PropertyDeclaration:
-					context.RegisterCodeFix(
-						CodeAction.Create("Use expression-bodied member", c => ReplaceWithExpressionBodiedMember(context.Document, (PropertyDeclarationSyntax)declaration, c)),
-						context.Diagnostics);
-					break;
+                case SyntaxKind.PropertyDeclaration:
+                    context.RegisterCodeFix(
+                        CodeAction.Create("Use expression-bodied member", c => ReplaceWithExpressionBodiedMember(context.Document, (PropertyDeclarationSyntax)declaration, c)),
+                        context.Diagnostics);
+                    break;
 
-				case SyntaxKind.IndexerDeclaration:
-					context.RegisterCodeFix(
-						CodeAction.Create("Use expression-bodied member", c => ReplaceWithExpressionBodiedMember(context.Document, (IndexerDeclarationSyntax)declaration, c)),
-						context.Diagnostics);
-					break;
-			}
-		}
+                case SyntaxKind.IndexerDeclaration:
+                    context.RegisterCodeFix(
+                        CodeAction.Create("Use expression-bodied member", c => ReplaceWithExpressionBodiedMember(context.Document, (IndexerDeclarationSyntax)declaration, c)),
+                        context.Diagnostics);
+                    break;
+            }
+        }
 
-		private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, MethodDeclarationSyntax declaration, CancellationToken cancellationToken)
-		{
-			var newDeclaration = declaration
-				.WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.Body)))
-				.WithBody(null)
-				.WithSemicolonToken(GetSemicolon(declaration.Body))
-				.WithAdditionalAnnotations(Formatter.Annotation);
+        private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, MethodDeclarationSyntax declaration, CancellationToken cancellationToken)
+        {
+            var newDeclaration = declaration
+                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.Body)))
+                .WithBody(null)
+                .WithSemicolonToken(GetSemicolon(declaration.Body))
+                .WithAdditionalAnnotations(Formatter.Annotation);
 
-			var root = await document.GetSyntaxRootAsync(cancellationToken);
-			var newRoot = root.ReplaceNode(declaration, newDeclaration);
+            var root = await document.GetSyntaxRootAsync(cancellationToken);
+            var newRoot = root.ReplaceNode(declaration, newDeclaration);
 
-			return document.WithSyntaxRoot(newRoot);
-		}
+            return document.WithSyntaxRoot(newRoot);
+        }
 
-		private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, OperatorDeclarationSyntax declaration, CancellationToken cancellationToken)
-		{
-			var newDeclaration = declaration
-				.WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.Body)))
-				.WithBody(null)
-				.WithSemicolonToken(GetSemicolon(declaration.Body))
-				.WithAdditionalAnnotations(Formatter.Annotation);
+        private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, OperatorDeclarationSyntax declaration, CancellationToken cancellationToken)
+        {
+            var newDeclaration = declaration
+                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.Body)))
+                .WithBody(null)
+                .WithSemicolonToken(GetSemicolon(declaration.Body))
+                .WithAdditionalAnnotations(Formatter.Annotation);
 
-			var root = await document.GetSyntaxRootAsync(cancellationToken);
-			var newRoot = root.ReplaceNode(declaration, newDeclaration);
+            var root = await document.GetSyntaxRootAsync(cancellationToken);
+            var newRoot = root.ReplaceNode(declaration, newDeclaration);
 
-			return document.WithSyntaxRoot(newRoot);
-		}
+            return document.WithSyntaxRoot(newRoot);
+        }
 
-		private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, ConversionOperatorDeclarationSyntax declaration, CancellationToken cancellationToken)
-		{
-			var newDeclaration = declaration
-				.WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.Body)))
-				.WithBody(null)
-				.WithSemicolonToken(GetSemicolon(declaration.Body))
-				.WithAdditionalAnnotations(Formatter.Annotation);
+        private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, ConversionOperatorDeclarationSyntax declaration, CancellationToken cancellationToken)
+        {
+            var newDeclaration = declaration
+                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.Body)))
+                .WithBody(null)
+                .WithSemicolonToken(GetSemicolon(declaration.Body))
+                .WithAdditionalAnnotations(Formatter.Annotation);
 
-			var root = await document.GetSyntaxRootAsync(cancellationToken);
-			var newRoot = root.ReplaceNode(declaration, newDeclaration);
+            var root = await document.GetSyntaxRootAsync(cancellationToken);
+            var newRoot = root.ReplaceNode(declaration, newDeclaration);
 
-			return document.WithSyntaxRoot(newRoot);
-		}
+            return document.WithSyntaxRoot(newRoot);
+        }
 
-		private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, PropertyDeclarationSyntax declaration, CancellationToken cancellationToken)
-		{
-			var newDeclaration = declaration
-				.WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.AccessorList)))
-				.WithAccessorList(null)
-				.WithSemicolonToken(GetSemicolon(declaration.AccessorList))
-				.WithAdditionalAnnotations(Formatter.Annotation);
+        private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, PropertyDeclarationSyntax declaration, CancellationToken cancellationToken)
+        {
+            var newDeclaration = declaration
+                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.AccessorList)))
+                .WithAccessorList(null)
+                .WithSemicolonToken(GetSemicolon(declaration.AccessorList))
+                .WithAdditionalAnnotations(Formatter.Annotation);
 
-			var root = await document.GetSyntaxRootAsync(cancellationToken);
-			var newRoot = root.ReplaceNode(declaration, newDeclaration);
+            var root = await document.GetSyntaxRootAsync(cancellationToken);
+            var newRoot = root.ReplaceNode(declaration, newDeclaration);
 
-			return document.WithSyntaxRoot(newRoot);
-		}
+            return document.WithSyntaxRoot(newRoot);
+        }
 
-		private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, IndexerDeclarationSyntax declaration, CancellationToken cancellationToken)
-		{
-			var newDeclaration = declaration
-				.WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.AccessorList)))
-				.WithAccessorList(null)
-				.WithSemicolonToken(GetSemicolon(declaration.AccessorList))
-				.WithAdditionalAnnotations(Formatter.Annotation);
+        private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, IndexerDeclarationSyntax declaration, CancellationToken cancellationToken)
+        {
+            var newDeclaration = declaration
+                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.AccessorList)))
+                .WithAccessorList(null)
+                .WithSemicolonToken(GetSemicolon(declaration.AccessorList))
+                .WithAdditionalAnnotations(Formatter.Annotation);
 
-			var root = await document.GetSyntaxRootAsync(cancellationToken);
-			var newRoot = root.ReplaceNode(declaration, newDeclaration);
+            var root = await document.GetSyntaxRootAsync(cancellationToken);
+            var newRoot = root.ReplaceNode(declaration, newDeclaration);
 
-			return document.WithSyntaxRoot(newRoot);
-		}
+            return document.WithSyntaxRoot(newRoot);
+        }
 
-		private static ExpressionSyntax GetExpression(BlockSyntax block)
-		{
-			return ((ReturnStatementSyntax)block.Statements[0]).Expression;
-		}
+        private static ExpressionSyntax GetExpression(BlockSyntax block)
+        {
+            return ((ReturnStatementSyntax)block.Statements[0]).Expression;
+        }
 
-		private static ExpressionSyntax GetExpression(AccessorListSyntax accessorList)
-		{
-			return ((ReturnStatementSyntax)accessorList.Accessors[0].Body.Statements[0]).Expression;
-		}
+        private static ExpressionSyntax GetExpression(AccessorListSyntax accessorList)
+        {
+            return ((ReturnStatementSyntax)accessorList.Accessors[0].Body.Statements[0]).Expression;
+        }
 
-		private static SyntaxToken GetSemicolon(BlockSyntax block)
-		{
-			var semicolon = ((ReturnStatementSyntax)block.Statements[0]).SemicolonToken;
+        private static SyntaxToken GetSemicolon(BlockSyntax block)
+        {
+            var semicolon = ((ReturnStatementSyntax)block.Statements[0]).SemicolonToken;
 
-			var trivia = semicolon.TrailingTrivia.AsEnumerable();
-			trivia = trivia.Where(t => !t.IsKind(SyntaxKind.EndOfLineTrivia));
+            var trivia = semicolon.TrailingTrivia.AsEnumerable();
+            trivia = trivia.Where(t => !t.IsKind(SyntaxKind.EndOfLineTrivia));
 
-			// Append trailing trivia from the closing brace.
-			var closeBraceTrivia = block.CloseBraceToken.TrailingTrivia.AsEnumerable();
-			trivia = trivia.Concat(closeBraceTrivia);
+            // Append trailing trivia from the closing brace.
+            var closeBraceTrivia = block.CloseBraceToken.TrailingTrivia.AsEnumerable();
+            trivia = trivia.Concat(closeBraceTrivia);
 
-			return semicolon.WithTrailingTrivia(trivia);
-		}
+            return semicolon.WithTrailingTrivia(trivia);
+        }
 
-		private static SyntaxToken GetSemicolon(AccessorListSyntax accessorList)
-		{
-			var semicolon = ((ReturnStatementSyntax)accessorList.Accessors[0].Body.Statements[0]).SemicolonToken;
+        private static SyntaxToken GetSemicolon(AccessorListSyntax accessorList)
+        {
+            var semicolon = ((ReturnStatementSyntax)accessorList.Accessors[0].Body.Statements[0]).SemicolonToken;
 
-			var trivia = semicolon.TrailingTrivia.AsEnumerable();
-			trivia = trivia.Where(t => !t.IsKind(SyntaxKind.EndOfLineTrivia));
+            var trivia = semicolon.TrailingTrivia.AsEnumerable();
+            trivia = trivia.Where(t => !t.IsKind(SyntaxKind.EndOfLineTrivia));
 
-			// Append trailing trivia from the closing brace.
-			var closeBraceTrivia = accessorList.CloseBraceToken.TrailingTrivia.AsEnumerable();
-			trivia = trivia.Concat(closeBraceTrivia);
+            // Append trailing trivia from the closing brace.
+            var closeBraceTrivia = accessorList.CloseBraceToken.TrailingTrivia.AsEnumerable();
+            trivia = trivia.Concat(closeBraceTrivia);
 
-			return semicolon.WithTrailingTrivia(trivia);
-		}
+            return semicolon.WithTrailingTrivia(trivia);
+        }
 
-		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticIds.UseExpressionBodiedMember);
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticIds.UseExpressionBodiedMember);
 
-		public override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-	}
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+    }
 }


### PR DESCRIPTION
"Expand expression-bodied member" refactoring makes it easy to convert from an expression-bodied member to a full member declaration with a body (and a get accessor declaration for properties and indexers).