### PR TITLE
Convert to Expression-Bodied Member should try to preserve leading comments

### DIFF
--- a/Source/CSharpEssentials.Tests/UseExpressionBodiedMember/UseExpressionBodiedMemberCodeFixTests.cs
+++ b/Source/CSharpEssentials.Tests/UseExpressionBodiedMember/UseExpressionBodiedMemberCodeFixTests.cs
@@ -165,5 +165,115 @@ class C
 
             TestCodeFix(markupCode, expected, DiagnosticDescriptors.UseExpressionBodiedMember);
         }
+
+        [Test]
+        public void TestMethodWithCommentBeforeReturn()
+        {
+            const string markupCode = @"
+class C
+{
+    [|int M()
+    {
+        // comment
+        return 42;
+    }|]
+}
+";
+
+            const string expected = @"
+class C
+{
+    // comment
+    int M() => 42;
+}
+";
+
+            TestCodeFix(markupCode, expected, DiagnosticDescriptors.UseExpressionBodiedMember);
+        }
+
+        [Test]
+        public void TestMethodWithCommentBeforeReturnAndXmlDocComment()
+        {
+            const string markupCode = @"
+class C
+{
+    /// <summary>Hello!</summary>
+    [|int M()
+    {
+        // comment
+        return 42;
+    }|]
+}
+";
+
+            const string expected = @"
+class C
+{
+    /// <summary>Hello!</summary>
+    // comment
+    int M() => 42;
+}
+";
+
+            TestCodeFix(markupCode, expected, DiagnosticDescriptors.UseExpressionBodiedMember);
+        }
+
+        [Test]
+        public void TestPropertyWithCommentBeforeReturn()
+        {
+            const string markupCode = @"
+class C
+{
+    [|int P
+    {
+        get
+        {
+            // comment
+            return 42;
+        }
+    }|]
+}
+";
+
+            const string expected = @"
+class C
+{
+    // comment
+    int P => 42;
+}
+";
+
+            TestCodeFix(markupCode, expected, DiagnosticDescriptors.UseExpressionBodiedMember);
+        }
+
+        [Test]
+        public void TestPropertyWithCommentBeforeReturnAndXmlDocComment()
+        {
+            const string markupCode = @"
+class C
+{
+    /// <summary>Hello!</summary>
+    [|int P
+    {
+        get
+        {
+            // comment
+            return 42;
+        }
+    }|]
+}
+";
+
+            const string expected = @"
+class C
+{
+    /// <summary>Hello!</summary>
+    // comment
+    int P => 42;
+}
+";
+
+            TestCodeFix(markupCode, expected, DiagnosticDescriptors.UseExpressionBodiedMember);
+        }
     }
 }

--- a/Source/CSharpEssentials/UseExpressionBodiedMember/UseExpressionBodiedMemberCodeFix.cs
+++ b/Source/CSharpEssentials/UseExpressionBodiedMember/UseExpressionBodiedMemberCodeFix.cs
@@ -55,8 +55,15 @@ namespace CSharpEssentials.UseExpressionBodiedMember
 
         private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, MethodDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
+            SyntaxTriviaList leadingTrivia;
+            var expression = GetExpressionAndLeadingTrivia(declaration.Body, out leadingTrivia);
+
+            var declarationTrivia = declaration.GetLeadingTrivia();
+            declarationTrivia = declarationTrivia.AddRange(leadingTrivia);
+
             var newDeclaration = declaration
-                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.Body)))
+                .WithLeadingTrivia(declarationTrivia)
+                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(expression))
                 .WithBody(null)
                 .WithSemicolonToken(GetSemicolon(declaration.Body))
                 .WithAdditionalAnnotations(Formatter.Annotation);
@@ -69,8 +76,15 @@ namespace CSharpEssentials.UseExpressionBodiedMember
 
         private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, OperatorDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
+            SyntaxTriviaList leadingTrivia;
+            var expression = GetExpressionAndLeadingTrivia(declaration.Body, out leadingTrivia);
+
+            var declarationTrivia = declaration.GetLeadingTrivia();
+            declarationTrivia = declarationTrivia.AddRange(leadingTrivia);
+
             var newDeclaration = declaration
-                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.Body)))
+                .WithLeadingTrivia(declarationTrivia)
+                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(expression))
                 .WithBody(null)
                 .WithSemicolonToken(GetSemicolon(declaration.Body))
                 .WithAdditionalAnnotations(Formatter.Annotation);
@@ -83,8 +97,15 @@ namespace CSharpEssentials.UseExpressionBodiedMember
 
         private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, ConversionOperatorDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
+            SyntaxTriviaList leadingTrivia;
+            var expression = GetExpressionAndLeadingTrivia(declaration.Body, out leadingTrivia);
+
+            var declarationTrivia = declaration.GetLeadingTrivia();
+            declarationTrivia = declarationTrivia.AddRange(leadingTrivia);
+
             var newDeclaration = declaration
-                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.Body)))
+                .WithLeadingTrivia(declarationTrivia)
+                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(expression))
                 .WithBody(null)
                 .WithSemicolonToken(GetSemicolon(declaration.Body))
                 .WithAdditionalAnnotations(Formatter.Annotation);
@@ -97,8 +118,15 @@ namespace CSharpEssentials.UseExpressionBodiedMember
 
         private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, PropertyDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
+            SyntaxTriviaList leadingTrivia;
+            var expression = GetExpression(declaration.AccessorList, out leadingTrivia);
+
+            var declarationTrivia = declaration.GetLeadingTrivia();
+            declarationTrivia = declarationTrivia.AddRange(leadingTrivia);
+
             var newDeclaration = declaration
-                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.AccessorList)))
+                .WithLeadingTrivia(declarationTrivia)
+                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(expression))
                 .WithAccessorList(null)
                 .WithSemicolonToken(GetSemicolon(declaration.AccessorList))
                 .WithAdditionalAnnotations(Formatter.Annotation);
@@ -111,8 +139,15 @@ namespace CSharpEssentials.UseExpressionBodiedMember
 
         private static async Task<Document> ReplaceWithExpressionBodiedMember(Document document, IndexerDeclarationSyntax declaration, CancellationToken cancellationToken)
         {
+            SyntaxTriviaList leadingTrivia;
+            var expression = GetExpression(declaration.AccessorList, out leadingTrivia);
+
+            var declarationTrivia = declaration.GetLeadingTrivia();
+            declarationTrivia = declarationTrivia.AddRange(leadingTrivia);
+
             var newDeclaration = declaration
-                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(GetExpression(declaration.AccessorList)))
+                .WithLeadingTrivia(declarationTrivia)
+                .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(expression))
                 .WithAccessorList(null)
                 .WithSemicolonToken(GetSemicolon(declaration.AccessorList))
                 .WithAdditionalAnnotations(Formatter.Annotation);
@@ -123,14 +158,24 @@ namespace CSharpEssentials.UseExpressionBodiedMember
             return document.WithSyntaxRoot(newRoot);
         }
 
-        private static ExpressionSyntax GetExpression(BlockSyntax block)
+        private static ExpressionSyntax GetExpressionAndLeadingTrivia(BlockSyntax block, out SyntaxTriviaList leadingTrivia)
         {
-            return ((ReturnStatementSyntax)block.Statements[0]).Expression;
+            var returnStatement = (ReturnStatementSyntax)block.Statements[0];
+            leadingTrivia = returnStatement.GetLeadingTrivia();
+
+            // TODO: Concatenate any trivia between the return keyword and the expression?
+
+            return returnStatement.Expression;
         }
 
-        private static ExpressionSyntax GetExpression(AccessorListSyntax accessorList)
+        private static ExpressionSyntax GetExpression(AccessorListSyntax accessorList, out SyntaxTriviaList leadingTrivia)
         {
-            return ((ReturnStatementSyntax)accessorList.Accessors[0].Body.Statements[0]).Expression;
+            var returnStatement = (ReturnStatementSyntax)accessorList.Accessors[0].Body.Statements[0];
+            leadingTrivia = returnStatement.GetLeadingTrivia();
+
+            // TODO: Concatenate any trivia between the return keyword and the expression?
+
+            return returnStatement.Expression;
         }
 
         private static SyntaxToken GetSemicolon(BlockSyntax block)


### PR DESCRIPTION
Fixes #24 

Any leading trivia to the return statement inside of a member should be moved to the start of the declaration, but after any existing leading trivia.